### PR TITLE
fixes #1

### DIFF
--- a/data/smc-libraries.csv
+++ b/data/smc-libraries.csv
@@ -1,43 +1,13 @@
-name,address,phone,longitude,latitude,geo_accuracy
-Atherton Library,"
-    3140 Woodside Road 
-    Woodside, CA 94062","
-    650.851.0147",-122.257048897959,37.4288816530612,house
-Belmont Library,"610 Elm Street, San Carlos, CA 94070","
-    650.591.0341",-122.26290443737,37.5048744748929,house
-Brisbane Library,"
-    765 Portola Road 
-    Portola Valley, CA 94028","
-    650.851.0560",-122.225040130689,37.3794925158982,house
-East Palo Alto Library,"
-    104 Hilton Way 
-    Pacifica, CA 94044","
-    650.355.5196",-122.492208982263,37.631990765314,house
-Foster City Library,"
-    1111 Terra Nova Boulevard 
-    Pacifica, CA 94044","
-    650.359.3397",-122.477301787648,37.5885774112162,house
-Half Moon Bay Library,"
-    1 Library Avenue 
-    Millbrae, CA 94030","
-    650.697.7607",-122.396422,37.603063,house
-Millbrae Library,"
-    620 Correas Street 
-    Half Moon Bay, CA 94019","
-    650.726.2316",-122.430208618725,37.4615830742753,house
-Pacifica Sanchez Library,"1000 East Hillsdale Boulevard, Foster City, CA 94404","
-    650.574.4842",-122.270821,37.559151,87
-Pacifica Sharp Park Library,"2415 University Avenue, East Palo Alto, CA 94303","
-    650.321.7712",-122.139572,37.473246,87
-Portola Valley Library,"
-    250 Visitacion Avenue 
-    Brisbane, CA 94005","
-    415.467.2060",-122.40379297886,37.6828032130851,library
-San Carlos Library,"
-    1110 Alameda de las Pulgas 
-    Belmont, CA 94002","
-    650.591.8286",-122.26536755102,37.4909158367347,house
-Woodside Library,"
-    2 Dinkelspiel Station Lane 
-    Atherton, CA 94027","
-    650.328.2422",-122.196267,37.463011,house
+"name","address","phone"
+"Atherton Library","2 Dinkelspiel Station Lane, Atherton, CA 94027","650.328.2422"
+"Belmont Library","1110 Alameda de las Pulgas, Belmont, CA 94002","650.591.8286"
+"Brisbane Library","250 Visitacion Avenue, Brisbane, CA 94005","415.467.2060"
+"East Palo Alto Library","2415 University Avenue, East, Palo Alto","650.321.7712"
+"Foster City Library","1000 East Hillsdale Boulevard, Foster, City CA","650.574.4842"
+"Half Moon Bay Library","620 Correas Street, Half, Moon Bay","650.726.2316"
+"Millbrae Library","1 Library Avenue, Millbrae, CA 94030","650.697.7607"
+"Pacifica Sanchez Library","1111 Terra Nova Boulevard, Pacifica, CA 94044","650.359.3397"
+"Pacifica Sharp Park Library","104 Hilton Way, Pacifica, CA 94044","650.355.5196"
+"Portola Valley Library","765 Portola Road, Portola, Valley CA","650.851.0560"
+"San Carlos Library","610 Elm Street, San, Carlos CA","650.591.0341"
+"Woodside Library","3140 Woodside Road, Woodside, CA 94062","650.851.0147"

--- a/data/smc_libraries_scraper.rb
+++ b/data/smc_libraries_scraper.rb
@@ -1,61 +1,40 @@
 require 'open-uri'
 require 'nokogiri'
 require 'CSV'
-
-page = open "http://www.smcl.org/node/36"
-
-html = Nokogiri::HTML page
-
+ 
+ENDPOINT = "http://www.smcl.org/node/36"
+ 
+html = Nokogiri::HTML open(ENDPOINT)
+ 
 # get all links in table cells with class = "location"
-all_links = html.css('td.location a')
-
+libraries = html.css("tbody tr")
+ 
 # retrieve only the second link in each table cell
 # the second link corresponds to the library's url
-library_urls = all_links.select.with_index{|_,i| (i+1) % 2 == 0 && (i+1)%4 != 0}
+rows = []
 
-# get each link's text (i.e the library name) and store in array
-library_names = []
-library_urls.each { |link| library_names.push(link.text) }
+libraries.each do |library|
+  result           = library.text.split("\r\n").reject {|chunk| chunk.strip.empty? }.map(&:strip)
 
-# get the rest of the libraries' info: address and phone number
-result = html.xpath('//td/text()[preceding-sibling::br]')
+  name             = result[0]
+  address          = result[1]
+  city, state, zip = result[2].scan(/\w+/)
+  phone            = result[3].scan(/\d+/).join(".")
 
-# the xpath method above returns 4 lines for each library:
-# 2 lines for the address, 1 line for the phone, 1 blank line
-# We want to get rid of the 4th blank line
-libraries_address_phone = result.select.with_index { |_,i| (i+1) % 4 != 0}
+  row = {
+    name:    name,
+    address: "#{address}, #{city}, #{state} #{zip}",
+    phone:   phone
+  }
 
-# Since each library now contains 3 lines of info,
-# the total number of libraries is the array's size divided by 3
-number_of_libraries = (libraries_address_phone.size)/3
-
-# In order to populate a CSV with this data, we need to do a few things:
-# 1) create an array of headers for each column
-headers = ["name", "address", "phone"]
-
-# 2) extract each library's address and phone into a separate array
-# We can do that by iterating through libraries_address_phone 
-# and popping every 3 elements into a new array
-array_of_library_info_arrays = []
-
-1.upto(number_of_libraries) do
- 	a = libraries_address_phone.pop(3)
- 	array_of_library_info_arrays.push(a)
+  rows << row
 end
+ 
+headers = [ :name, :address, :phone ]
 
-# 3) join the first 2 address lines of each library into one array element
-array_of_library_info_arrays.each do |library| 
-	joined_addresses = library[0..1].join(", ") #this returns a string
-	library.slice!(0..1) # remove the 2 address elements from the array
-	library.insert(0, joined_addresses) # put the joined address back into the array as one element
-end
-
-# 4) insert the library name into each library's array
-library_names.each_with_index do |name, i|
-	array_of_library_info_arrays[i].insert(0, name)
-end
-
-CSV.open("smc-libraries.csv", "wb") do |csv|
-	csv << headers
-	array_of_library_info_arrays.each { |row| csv << row }
+CSV.open("smc-libraries.csv", "wb", :force_quotes => true) do |csv|
+  csv << headers
+  rows.map(&:values).each do |row|
+    csv << row
+  end
 end


### PR DESCRIPTION
uses @rclosner's much more elegant and concise scraper, which I edited to put the address, city, state, and zip all in one line (preferred format for geocoding). Also added the :force_quotes => true option to enclose all fields with quotes.
